### PR TITLE
Restrict log batches based on chronological order and time span

### DIFF
--- a/docs/api-protected.md
+++ b/docs/api-protected.md
@@ -26,7 +26,7 @@
     * [.onError(err, logEvents, next)](#CWLogsWritable+onError)
     * [.filterWrite(rec)](#CWLogsWritable+filterWrite) ⇒ <code>boolean</code>
     * [.createService(opts)](#CWLogsWritable+createService) ⇒ <code>CloudWatchLogs</code>
-    * [.nextLogBatchSize(queuedLogs)](#CWLogsWritable+nextLogBatchSize) ⇒ <code>number</code>
+    * [.dequeueNextLogBatch()](#CWLogsWritable+dequeueNextLogBatch) ⇒ <code>Array.&lt;{message: string, timestamp: number}&gt;</code>
     * [.getMessageSize(message)](#CWLogsWritable+getMessageSize) ⇒ <code>number</code>
     * ["putLogEvents" (logEvents)](#CWLogsWritable+event_putLogEvents)
     * ["createLogGroup"](#CWLogsWritable+event_createLogGroup)
@@ -299,19 +299,15 @@ Create the AWS.CloudWatchLogs service.
 
 - opts <code>object</code> - Passed as first argument to AWS.CloudWatchLogs.
 
-<a name="CWLogsWritable+nextLogBatchSize"></a>
+<a name="CWLogsWritable+dequeueNextLogBatch"></a>
 
-### cwLogsWritable.nextLogBatchSize(queuedLogs) ⇒ <code>number</code>
-Get the size of the next batch of log events to send,
+### cwLogsWritable.dequeueNextLogBatch() ⇒ <code>Array.&lt;{message: string, timestamp: number}&gt;</code>
+Get the next batch of log events to send,
 based on the the constraints of PutLogEvents.
 
 **Kind**: instance method of <code>[CWLogsWritable](#CWLogsWritable)</code>  
 **Access:** protected  
 **See**: http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html  
-**Params**
-
-- queuedLogs <code>Array.&lt;{message:string, timestamp:number}&gt;</code> - Number of bytes used by other JSON.
-
 <a name="CWLogsWritable+getMessageSize"></a>
 
 ### cwLogsWritable.getMessageSize(message) ⇒ <code>number</code>

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var Writable = require('stream').Writable;
 var AWS = require('aws-sdk');
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 var safeStringify = require('./safe-stringify');
+var oneDay = 86400000;
 
 module.exports = CWLogsWritable;
 
@@ -409,38 +410,73 @@ CWLogsWritable.prototype.createService = function(opts) {
 };
 
 /**
- * Get the size of the next batch of log events to send,
+ * Get the next batch of log events to send,
  * based on the the constraints of PutLogEvents.
  *
  * @protected
  * @see http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
- * @param {Array.<{message:string,timestamp:number}>} queuedLogs - Number of bytes used by other JSON.
- * @returns {number}
+ * @returns {Array.<{message: string, timestamp: number}>}
  */
-CWLogsWritable.prototype.nextLogBatchSize = function(queuedLogs) {
+CWLogsWritable.prototype.dequeueNextLogBatch = function() {
+	if (!this.queuedLogs.length) {
+		return [];
+	}
+
 	var batchCount = 1;
 	var sizeEstimate = 0;
+	var earliestTimestamp = this.queuedLogs[0].timestamp;
+	var lastTimestamp = earliestTimestamp;
+	var needsSorting = false;
 
+	// Rules for PutLogEvents:
 	// (DONE) The maximum batch size is 1,048,576 bytes, and this size is calculated as the sum of all event messages in UTF-8, plus 26 bytes for each log event.
 	// (SKIP) None of the log events in the batch can be more than 2 hours in the future.
 	// (SKIP) None of the log events in the batch can be older than 14 days or the retention period of the log group.
-	// TODO: The log events in the batch must be in chronological ordered by their timestamp (the time the event occurred, expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC).
+	// (DONE) The log events in the batch must be in chronological ordered by their timestamp (the time the event occurred, expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC).
 	// (DONE) The maximum number of log events in a batch is 10,000.
-	// TODO: A batch of log events in a single request cannot span more than 24 hours. Otherwise, the operation fails.
+	// (DONE) A batch of log events in a single request cannot span more than 24 hours. Otherwise, the operation fails.
 
-	for (var i = 0, l = queuedLogs.length; i < l; i++) {
-		sizeEstimate += 26 + this.getMessageSize(queuedLogs[i].message);
+	for (var i = 0, l = this.queuedLogs.length; i < l; i++) {
+		var logEvent = this.queuedLogs[i];
+
+		// Cut off if the logs would no longer fit within 24 hours.
+		if (logEvent.timestamp > earliestTimestamp + oneDay) {
+			break;
+		}
+
+		if (lastTimestamp > logEvent.timestamp) {
+			needsSorting = true;
+		}
+
+		lastTimestamp = logEvent.timestamp;
+		sizeEstimate += 26 + this.getMessageSize(logEvent.message);
 
 		// Cut off at the max bytes limit.
 		if (sizeEstimate > this.maxBatchSize || batchCount >= this.maxBatchCount) {
 			break;
 		}
-		else {
-			batchCount = i + 1;
-		}
+
+		batchCount = i + 1;
 	}
 
-	return batchCount;
+	var batch;
+
+	// Put all queued items since they fit.
+	if (batchCount === this.queuedLogs.length) {
+		batch = this.queuedLogs;
+		this.queuedLogs = [];
+	}
+
+	// Queue just the items that fit within a PutLogEvents call.
+	else {
+		batch = this.queuedLogs.splice(0, batchCount);
+	}
+
+	if (needsSorting) {
+		batch.sort(logEventComparator);
+	}
+
+	return batch;
 };
 
 /**
@@ -544,24 +580,12 @@ CWLogsWritable.prototype._sendLogs = function() {
 		return;
 	}
 
-	var batchCount = this.nextLogBatchSize(this.queuedLogs);
-
 	var apiParams = {
 		logGroupName: this.logGroupName,
 		logStreamName: this.logStreamName,
 		sequenceToken: this.sequenceToken,
-		logEvents: null
+		logEvents: this.dequeueNextLogBatch()
 	};
-
-	if (batchCount === this.queuedLogs.length) {
-		// Put all queued items since they fit
-		apiParams.logEvents = this.queuedLogs;
-		this.queuedLogs = [];
-	}
-	else {
-		// Queue just the items that fit within a putLogEvents call
-		apiParams.logEvents = this.queuedLogs.splice(0, batchCount);
-	}
 
 	this._putLogEvents(apiParams, function(err, sequenceToken) {
 		if (err) {
@@ -833,4 +857,9 @@ function isFiniteNumber(val) {
 
 function isInterval(val) {
 	return val === 'nextTick' || isFiniteNumber(val) && val >= 0;
+}
+
+function logEventComparator(a, b) {
+	return a.timestamp < b.timestamp ? -1
+		: a.timestamp > b.timestamp ? 1 : 0;
 }


### PR DESCRIPTION
* Add live tests for chronological limits of PutLogEvents
* Handle chronological limits of PutLogEvents API call [#2]
   * Batch of log events must be in chronological order by timestamp
   * Batch of log events cannot exceed 24 hours