### PR TITLE
Fix error thrown if no error listeners

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -665,7 +665,12 @@ CWLogsWritable.prototype._nextAfterError = function(_onErrorNextCbId, errOrLogEv
  * @private
  */
 CWLogsWritable.prototype._handleError = function(err) {
-	this.emit('error', err);
+	// Only throw error if there are listeners.
+	// See https://nodejs.org/docs/latest-v4.x/api/events.html#events_emitter_listenercount_eventname
+	if (this.listeners('error').length) {
+		this.emit('error', err);
+	}
+
 	this.clearQueue();
 	this.filterWrite = CWLogsWritable._falseFilterWrite;
 };

--- a/test/CWLogsWritable.spec.js
+++ b/test/CWLogsWritable.spec.js
@@ -2087,6 +2087,23 @@ describe('CWLogsWritable', function() {
 			expect(clearQueueSpy.calls.length).toBe(1);
 			expect(stream.filterWrite).toBe(CWLogsWritable._falseFilterWrite);
 		});
+
+		it('should not emit "error" event if there are no listeners', function() {
+			var expectedError = new Error();
+			var stream = new CWLogsWritable({
+				logGroupName: 'foo',
+				logStreamName: 'bar'
+			});
+
+			var clearQueueSpy = expect.spyOn(stream, 'clearQueue');
+
+			var emitSpy = expect.spyOn(stream, 'emit').andCallThrough();
+
+			stream._handleError(expectedError);
+			expect(emitSpy.calls.length).toBe(0);
+			expect(clearQueueSpy.calls.length).toBe(1);
+			expect(stream.filterWrite).toBe(CWLogsWritable._falseFilterWrite);
+		});
 	});
 
 	describe('CWLogsWritable._falseFilterWrite', function() {

--- a/test/aws-livetest.spec.js
+++ b/test/aws-livetest.spec.js
@@ -46,7 +46,7 @@ describe('AWS Live Test', function() {
 		});
 
 		stream.on('error', function(err) {
-			throw err;
+			done(err);
 		});
 
 		stream.on('putLogEvents', function(logEvents) {
@@ -78,9 +78,7 @@ describe('AWS Live Test', function() {
 		expect(maxSize).toBe(262118);
 
 		stream.on('error', function(err) {
-			//console.error({ m: err.message, c: err.code, s: err.statusCode });
-			//console.log(Object.keys(err));
-			throw err;
+			done(err);
 		});
 
 		stream.on('putLogEvents', function(logEvents) {
@@ -113,7 +111,7 @@ describe('AWS Live Test', function() {
 		});
 
 		stream.on('putLogEvents', function() {
-			throw new Error('Expected not to succeed');
+			done(new Error('Expected not to succeed'));
 		});
 
 		var largeMessage = new Array(maxSize + 2).join('0');
@@ -132,7 +130,7 @@ describe('AWS Live Test', function() {
 		});
 
 		stream.on('error', function(err) {
-			throw err;
+			done(err);
 		});
 
 		stream.on('putLogEvents', function(logEvents) {
@@ -178,7 +176,7 @@ describe('AWS Live Test', function() {
 		});
 
 		stream.onError = function() {
-			throw new Error('Expected not to be called');
+			done(new Error('Expected not to be called'));
 		};
 
 		stream.write('foo');

--- a/test/aws-livetest.spec.js
+++ b/test/aws-livetest.spec.js
@@ -63,6 +63,58 @@ describe('AWS Live Test', function() {
 		}
 	});
 
+	it('should handle invalid accessKeyId (UnrecognizedClientException)', function(done) {
+		var stream = new CWLogsWritable({
+			logGroupName: logGroupName,
+			logStreamName: logStreamName,
+			onError: function(err) {
+				expect(err.code).toBe('UnrecognizedClientException');
+
+				// Set delay to make sure AWS-SDK doesn't throw an error.
+				setTimeout(function() {
+					done();
+				}, 50);
+			},
+			cloudWatchLogsOptions: {
+				region: region,
+				accessKeyId: 'nope',
+				secretAccessKey: 'nope'
+			}
+		});
+
+		stream.write('foo');
+
+		stream.on('putLogEvents', function() {
+			done(new Error('Expected to not be called'));
+		});
+	});
+
+	it('should handle invalid secretAccessKey (InvalidSignatureException)', function(done) {
+		var stream = new CWLogsWritable({
+			logGroupName: logGroupName,
+			logStreamName: logStreamName,
+			onError: function(err) {
+				expect(err.code).toBe('InvalidSignatureException');
+
+				// Set delay to make sure AWS-SDK doesn't throw an error.
+				setTimeout(function() {
+					done();
+				}, 50);
+			},
+			cloudWatchLogsOptions: {
+				region: region,
+				accessKeyId: accessKeyId,
+				secretAccessKey: '0OKW39DejMUcepCSKAkYuKLwuz3k60VdJXinDQHS'
+			}
+		});
+
+		stream.write('foo');
+
+		stream.on('putLogEvents', function() {
+			done(new Error('Expected to not be called'));
+		});
+	});
+
 	it('should allow up to 262118 bytes (256 KB - 26 bytes) for the message', function(done) {
 		var stream = new CWLogsWritable({
 			logGroupName: logGroupName,


### PR DESCRIPTION
**Non-Breaking Changes:**

* Add live tests for invalid credentials
* Change AWS live tests to use "done" instead of throwing errors
* Fix error thrown if no 'error' event listeners on stream [#15]
