### PR TITLE
Fix determining log "message" size not handling multi-byte chars

### DIFF
--- a/docs/api-protected.md
+++ b/docs/api-protected.md
@@ -311,24 +311,18 @@ based on the the constraints of PutLogEvents.
 <a name="CWLogsWritable+getMessageSize"></a>
 
 ### cwLogsWritable.getMessageSize(message) ⇒ <code>number</code>
-Get the size of the message, which is used while determining
-how many messages can fit within a single PutLogEvents API call.
+Get the size of the message in bytes.
 
-By default this is calculated by the length of the string.
-
-However, if a string contains multi-byte UTF characters the size
-will be off which may result in a PutLogEvents error.
-
-For example, "I \u2764 AWS" is 7 characters but 9 bytes.
+By default this is calculated as the string character length × 4
+(UTF-8 characters can have up to 4 bytes), which is cheaper
+than determining the exact byte length.
 
 You may override this method to provide your own implementation
-to correctly measure string sizes.
-
-Alternatively, you can reduce `maxBatchSize` to a number that
-takes into account possible UTF-8 characters.
+to correctly measure the number of bytes in the string
+(i.e. using [Buffer.byteLength()](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_bytelength_string_encoding)).
 
 **Kind**: instance method of <code>[CWLogsWritable](#CWLogsWritable)</code>  
-**Returns**: <code>number</code> - The size of the message.  
+**Returns**: <code>number</code> - The size of the message in bytes.  
 **Access:** protected  
 **Params**
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -480,28 +480,22 @@ CWLogsWritable.prototype.dequeueNextLogBatch = function() {
 };
 
 /**
- * Get the size of the message, which is used while determining
- * how many messages can fit within a single PutLogEvents API call.
+ * Get the size of the message in bytes.
  *
- * By default this is calculated by the length of the string.
- *
- * However, if a string contains multi-byte UTF characters the size
- * will be off which may result in a PutLogEvents error.
- *
- * For example, "I \u2764 AWS" is 7 characters but 9 bytes.
+ * By default this is calculated as the string character length × 4
+ * (UTF-8 characters can have up to 4 bytes), which is cheaper
+ * than determining the exact byte length.
  *
  * You may override this method to provide your own implementation
- * to correctly measure string sizes.
- *
- * Alternatively, you can reduce `maxBatchSize` to a number that
- * takes into account possible UTF-8 characters.
+ * to correctly measure the number of bytes in the string
+ * (i.e. using [Buffer.byteLength()](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_bytelength_string_encoding)).
  *
  * @protected
  * @param {string} message - The "message" prop of a LogEvent.
- * @returns {number} The size of the message.
+ * @returns {number} The size of the message in bytes.
  */
 CWLogsWritable.prototype.getMessageSize = function(message) {
-	return message.length;
+	return message.length * 4;
 };
 
 /**


### PR DESCRIPTION
**Non-Breaking Changes:**

* Fix determining log "message" size not handling multi-byte chars [#13]