### PR TITLE
Fix not validating for max bytes per-message limit

### DIFF
--- a/docs/api-protected.md
+++ b/docs/api-protected.md
@@ -28,10 +28,12 @@
     * [.createService(opts)](#CWLogsWritable+createService) ⇒ <code>CloudWatchLogs</code>
     * [.dequeueNextLogBatch()](#CWLogsWritable+dequeueNextLogBatch) ⇒ <code>Array.&lt;{message: string, timestamp: number}&gt;</code>
     * [.getMessageSize(message)](#CWLogsWritable+getMessageSize) ⇒ <code>number</code>
+    * [.reduceOversizedMessage(logEventMessage)](#CWLogsWritable+reduceOversizedMessage) ⇒ <code>\*</code> &#124; <code>string</code>
     * ["putLogEvents" (logEvents)](#CWLogsWritable+event_putLogEvents)
     * ["createLogGroup"](#CWLogsWritable+event_createLogGroup)
     * ["createLogStream"](#CWLogsWritable+event_createLogStream)
     * ["stringifyError" (err, rec)](#CWLogsWritable+event_stringifyError)
+    * ["oversizeLogEvent" (logEventMessage)](#CWLogsWritable+event_oversizeLogEvent)
 
 <a name="new_CWLogsWritable_new"></a>
 
@@ -328,6 +330,27 @@ to correctly measure the number of bytes in the string
 
 - message <code>string</code> - The "message" prop of a LogEvent.
 
+<a name="CWLogsWritable+reduceOversizedMessage"></a>
+
+### cwLogsWritable.reduceOversizedMessage(logEventMessage) ⇒ <code>\*</code> &#124; <code>string</code>
+Attempt to reduce the specified message so it fits within the
+262118 byte limit enforced by PutLogEvents.
+
+Only called for messages that are over the byte limit.
+
+Use [Buffer.byteLength()](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_bytelength_string_encoding)
+to accurately measure the message size before returning it.
+
+If the string returned is still over the byte limit, this method
+will _not_ be called again for the log event.
+
+**Kind**: instance method of <code>[CWLogsWritable](#CWLogsWritable)</code>  
+**Returns**: <code>\*</code> &#124; <code>string</code> - - The reduced string, or a non-string (i.e. undefined or null) indicating the message cannot be reduced.  
+**See**: {CWLogsWritable#event:oversizeLogEvent}  
+**Params**
+
+- logEventMessage <code>string</code> - Stringified log event.
+
 <a name="CWLogsWritable+event_putLogEvents"></a>
 
 ### "putLogEvents" (logEvents)
@@ -360,4 +383,14 @@ Fired when an error is thrown while stringifying a log event.
 
 - err <code>Error</code>
 - rec <code>object</code> | <code>string</code>
+
+<a name="CWLogsWritable+event_oversizeLogEvent"></a>
+
+### "oversizeLogEvent" (logEventMessage)
+Fired when a log event message is larger than the 262118 byte limit enforced by PutLogEvents.
+
+**Kind**: event emitted by <code>[CWLogsWritable](#CWLogsWritable)</code>  
+**Params**
+
+- logEventMessage <code>string</code> - Stringified log event.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -21,10 +21,12 @@
     * [.clearQueue()](#CWLogsWritable+clearQueue) ⇒ <code>Array.&lt;{message:string, timestamp:number}&gt;</code>
     * [.onError(err, logEvents, next)](#CWLogsWritable+onError)
     * [.filterWrite(rec)](#CWLogsWritable+filterWrite) ⇒ <code>boolean</code>
+    * [.reduceOversizedMessage(logEventMessage)](#CWLogsWritable+reduceOversizedMessage) ⇒ <code>\*</code> &#124; <code>string</code>
     * ["putLogEvents" (logEvents)](#CWLogsWritable+event_putLogEvents)
     * ["createLogGroup"](#CWLogsWritable+event_createLogGroup)
     * ["createLogStream"](#CWLogsWritable+event_createLogStream)
     * ["stringifyError" (err, rec)](#CWLogsWritable+event_stringifyError)
+    * ["oversizeLogEvent" (logEventMessage)](#CWLogsWritable+event_oversizeLogEvent)
 
 <a name="new_CWLogsWritable_new"></a>
 
@@ -237,6 +239,27 @@ Default behavior is to return true if `rec` is not null or undefined.
 
 - rec <code>string</code> | <code>object</code> - Raw log record passed to Writable#write.
 
+<a name="CWLogsWritable+reduceOversizedMessage"></a>
+
+### cwLogsWritable.reduceOversizedMessage(logEventMessage) ⇒ <code>\*</code> &#124; <code>string</code>
+Attempt to reduce the specified message so it fits within the
+262118 byte limit enforced by PutLogEvents.
+
+Only called for messages that are over the byte limit.
+
+Use [Buffer.byteLength()](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_bytelength_string_encoding)
+to accurately measure the message size before returning it.
+
+If the string returned is still over the byte limit, this method
+will _not_ be called again for the log event.
+
+**Kind**: instance method of <code>[CWLogsWritable](#CWLogsWritable)</code>  
+**Returns**: <code>\*</code> &#124; <code>string</code> - - The reduced string, or a non-string (i.e. undefined or null) indicating the message cannot be reduced.  
+**See**: {CWLogsWritable#event:oversizeLogEvent}  
+**Params**
+
+- logEventMessage <code>string</code> - Stringified log event.
+
 <a name="CWLogsWritable+event_putLogEvents"></a>
 
 ### "putLogEvents" (logEvents)
@@ -269,4 +292,14 @@ Fired when an error is thrown while stringifying a log event.
 
 - err <code>Error</code>
 - rec <code>object</code> | <code>string</code>
+
+<a name="CWLogsWritable+event_oversizeLogEvent"></a>
+
+### "oversizeLogEvent" (logEventMessage)
+Fired when a log event message is larger than the 262118 byte limit enforced by PutLogEvents.
+
+**Kind**: event emitted by <code>[CWLogsWritable](#CWLogsWritable)</code>  
+**Params**
+
+- logEventMessage <code>string</code> - Stringified log event.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ var AWS = require('aws-sdk');
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 var safeStringify = require('./safe-stringify');
 var ONE_DAY = 86400000;
+var MAX_MESSAGE_SIZE = 262118;
 
 module.exports = CWLogsWritable;
 
@@ -427,8 +428,10 @@ CWLogsWritable.prototype.dequeueNextLogBatch = function() {
 	var earliestTimestamp = this.queuedLogs[0].timestamp;
 	var lastTimestamp = earliestTimestamp;
 	var needsSorting = false;
+	var dropIndexes = [];
 
 	// Rules for PutLogEvents:
+	// (DONE) Log event message cannot be more than 262,118 bytes (256 * 1024 - 26)
 	// (DONE) The maximum batch size is 1,048,576 bytes, and this size is calculated as the sum of all event messages in UTF-8, plus 26 bytes for each log event.
 	// (SKIP) None of the log events in the batch can be more than 2 hours in the future.
 	// (SKIP) None of the log events in the batch can be older than 14 days or the retention period of the log group.
@@ -437,6 +440,7 @@ CWLogsWritable.prototype.dequeueNextLogBatch = function() {
 	// (DONE) A batch of log events in a single request cannot span more than 24 hours. Otherwise, the operation fails.
 
 	for (var i = 0, l = this.queuedLogs.length; i < l; i++) {
+		var dropLogEvent = false;
 		var logEvent = this.queuedLogs[i];
 
 		// Cut off if the logs would no longer fit within 24 hours.
@@ -444,16 +448,48 @@ CWLogsWritable.prototype.dequeueNextLogBatch = function() {
 			break;
 		}
 
-		if (lastTimestamp > logEvent.timestamp) {
-			needsSorting = true;
+		var messageSize = this.getMessageSize(logEvent.message);
+
+		// Handle messages beyond the limit allowed by PutLogEvents.
+		if (messageSize > MAX_MESSAGE_SIZE) {
+			var reducedMessage = this.reduceOversizedMessage(logEvent.message);
+
+			// Drop the log event if the message could not be reduced.
+			if (typeof reducedMessage !== 'string') {
+				dropLogEvent = true;
+				this._emitOversizeLogEvent(logEvent.message);
+			}
+			else {
+				messageSize = this.getMessageSize(reducedMessage);
+
+				// Drop the log event if the message is still over the limit.
+				if (messageSize > MAX_MESSAGE_SIZE) {
+					dropLogEvent = true;
+					this._emitOversizeLogEvent(logEvent.message);
+				}
+
+				// Otherwise, use the now reduced message.
+				else {
+					logEvent.message = reducedMessage;
+				}
+			}
 		}
 
-		lastTimestamp = logEvent.timestamp;
-		sizeEstimate += 26 + this.getMessageSize(logEvent.message);
+		if (dropLogEvent) {
+			dropIndexes.push(i);
+		}
+		else {
+			if (lastTimestamp > logEvent.timestamp) {
+				needsSorting = true;
+			}
 
-		// Cut off at the max bytes limit.
-		if (sizeEstimate > this.maxBatchSize || batchCount >= this.maxBatchCount) {
-			break;
+			lastTimestamp = logEvent.timestamp;
+			sizeEstimate += 26 + messageSize;
+
+			// Cut off at the max bytes limit.
+			if (sizeEstimate > this.maxBatchSize || batchCount - dropIndexes.length >= this.maxBatchCount) {
+				break;
+			}
 		}
 
 		batchCount = i + 1;
@@ -470,6 +506,13 @@ CWLogsWritable.prototype.dequeueNextLogBatch = function() {
 	// Queue just the items that fit within a PutLogEvents call.
 	else {
 		batch = this.queuedLogs.splice(0, batchCount);
+	}
+
+	// Remove any entries that are being dropped.
+	if (dropIndexes.length) {
+		for (var si = dropIndexes.length - 1; si >= 0; si--) {
+			batch.splice(dropIndexes[si], 1);
+		}
 	}
 
 	if (needsSorting) {
@@ -495,7 +538,35 @@ CWLogsWritable.prototype.dequeueNextLogBatch = function() {
  * @returns {number} The size of the message in bytes.
  */
 CWLogsWritable.prototype.getMessageSize = function(message) {
-	return message.length * 4;
+	// Estimate size assuming each character is 4 bytes.
+	var size = message.length * 4;
+
+	// Calculate exact bytes if estimate is over message limit.
+	if (size > MAX_MESSAGE_SIZE) {
+		size = Buffer.byteLength(message, 'utf8');
+	}
+
+	return size;
+};
+
+/**
+ * Attempt to reduce the specified message so it fits within the
+ * 262118 byte limit enforced by PutLogEvents.
+ *
+ * Only called for messages that are over the byte limit.
+ *
+ * Use [Buffer.byteLength()](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_bytelength_string_encoding)
+ * to accurately measure the message size before returning it.
+ *
+ * If the string returned is still over the byte limit, this method
+ * will _not_ be called again for the log event.
+ *
+ * @see {CWLogsWritable#event:oversizeLogEvent}
+ * @param {string} logEventMessage - Stringified log event.
+ * @returns {*|string} - The reduced string, or a non-string (i.e. undefined or null) indicating the message cannot be reduced.
+ */
+CWLogsWritable.prototype.reduceOversizedMessage = function(logEventMessage) { // eslint-disable-line no-unused-vars
+	return null;
 };
 
 /**
@@ -844,6 +915,16 @@ CWLogsWritable.prototype._emitCreateLogStream = function() {
  */
 CWLogsWritable.prototype._emitStringifyError = function(err, rec) {
 	this.emit('stringifyError', err, rec);
+};
+
+/**
+ * Fired when a log event message is larger than the 262118 byte limit enforced by PutLogEvents.
+ *
+ * @event CWLogsWritable#oversizeLogEvent
+ * @param {string} logEventMessage - Stringified log event.
+ */
+CWLogsWritable.prototype._emitOversizeLogEvent = function(logEventMessage) {
+	this.emit('oversizeLogEvent', logEventMessage);
 };
 
 CWLogsWritable._falseFilterWrite = function() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ var Writable = require('stream').Writable;
 var AWS = require('aws-sdk');
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 var safeStringify = require('./safe-stringify');
-var oneDay = 86400000;
+var ONE_DAY = 86400000;
 
 module.exports = CWLogsWritable;
 
@@ -440,7 +440,7 @@ CWLogsWritable.prototype.dequeueNextLogBatch = function() {
 		var logEvent = this.queuedLogs[i];
 
 		// Cut off if the logs would no longer fit within 24 hours.
-		if (logEvent.timestamp > earliestTimestamp + oneDay) {
+		if (logEvent.timestamp > earliestTimestamp + ONE_DAY) {
 			break;
 		}
 


### PR DESCRIPTION
**Non-Breaking Changes:**

* Add CWLogsWritable#reduceOversizedMessage method to allow custom
  handling of oversized messages to reduce their size.
* Add "oversizeLogEvent" event that is fired for messages that are
  dropped due to their size.
* Change CWLogsWritable#getMessageSize to accurately measure the byte
  size if the estimate puts it over the max size.
* Change CWLogsWritable#dequeueNextLogBatch to drop log events if:
    * getMessageSize returns a size for the message that is over the
      limit, and...
    * Passing the message through reduceOversizedMessage does not
      reduce the message to fit within the limit.